### PR TITLE
Fix typos in the documentation

### DIFF
--- a/doc/DocumentationAuralization.md
+++ b/doc/DocumentationAuralization.md
@@ -1,6 +1,6 @@
 ﻿# Auralization Documentation
 
-An auralization is an audible file that is created by the convolution of an anaechoic audio signal with a simulated room impulse response. It shows how a specific sound (the sound produced by the anechoic file) would sound in the room specifically simulated (room impulse response). The diffusion equation method is the method used to produce the energy densities inside the room, which needs to be converted into a time-domain impulse reponse usable for auralization.
+An auralization is an audible file that is created by the convolution of an anaechoic audio signal with a simulated room impulse response. It shows how a specific sound (the sound produced by the anechoic file) would sound in the room specifically simulated (room impulse response). The diffusion equation method is the method used to produce the energy densities inside the room, which needs to be converted into a time-domain impulse response usable for auralization.
 
 In order to create an auralization, the first step is to get the results from the diffusion equation method. 
 In particular, the diffusion equation simulator provides the energy density at the receiver position. To make it audible, acoustic pressure is needed which is related to the energy density by the formula $p_\mathrm{rec}^2 = w_{rec} \rho c_0^2$, where $w_\mathrm{rec}$ is the energy density at the receiver, $\rho$ is the air density in kg/m³ and $c_0$ is the speed of sound.   
@@ -15,7 +15,7 @@ Next, random noise needs to be created, to represent the random phase fluctuatio
 
 Since each octave band is modeled separately in the diffusion equation model, a Butterwoth bandpass filter ensures that the random noise occupies the correct frequency range. This step include the creation of the filter for the random noise. A order 8 for the bandpass filter ensures that the transition band is sharp enough to isolate the frequency regions while keeping stability.
 
-The filtered random noise is created by convolving the time domain of the Butterworth bandpass filter and the random noise for each frequency band. This gives the noise in each frequency the correct spectral charateristic. 
+The filtered random noise is created by convolving the time domain of the Butterworth bandpass filter and the random noise for each frequency band. This gives the noise in each frequency the correct spectral characteristic. 
 
 The square-root of the envelope of the impulse response (calculated at step 2) is to be padded to get the same length of the filtered random noise (calculated at step 5). Padding ensures temporal alignment without distorting the envelope and allows for element-wise multiplication.
 

--- a/doc/DocumentationFDM.md
+++ b/doc/DocumentationFDM.md
@@ -14,7 +14,7 @@ The model for the sound energy density $w(\mathbf{r}, t)$ at position $\mathbf{r
 + c m w(\mathbf{r}, t) = P(t)\delta(\mathbf{r} - \mathbf{r}_s)
 ```
 
-where $\frac{\partial^2}{\partial x^2}$, $\frac{\partial^2}{\partial y^2}$, $\frac{\partial^2}{\partial z^2}$ are the Laplace operators and $D = \frac{\lambda c}{3}$ is the so-called theoretical diffusion coefficient with $c$ being the speed of sound. The diffusion coefficient is a constant value that takes into account the room geometry and volume trough the mean free path defined for proportionate rooms as $\lambda = \frac{4 V}{S}$ with volume $V$ of the room and $S$ the total surface area. The term $P(t)$ indicates a sound source term at position $r_s$. The term $c m w(\mathbf{r}, t)$ accounts for the atmospheric attenuation within the room, where $m$ is the absorption coefficient of air (Billon et al., 2008).
+where $\frac{\partial^2}{\partial x^2}$, $\frac{\partial^2}{\partial y^2}$, $\frac{\partial^2}{\partial z^2}$ are the Laplace operators and $D = \frac{\lambda c}{3}$ is the so-called theoretical diffusion coefficient with $c$ being the speed of sound. The diffusion coefficient is a constant value that takes into account the room geometry and volume through the mean free path defined for proportionate rooms as $\lambda = \frac{4 V}{S}$ with volume $V$ of the room and $S$ the total surface area. The term $P(t)$ indicates a sound source term at position $r_s$. The term $c m w(\mathbf{r}, t)$ accounts for the atmospheric attenuation within the room, where $m$ is the absorption coefficient of air (Billon et al., 2008).
 
 The main partial differential equation is associated with mixed boundary conditions on a domain $\partial V$, as follows:
 

--- a/doc/DocumentationFVM.md
+++ b/doc/DocumentationFVM.md
@@ -14,7 +14,7 @@ The model for the sound energy density $w(\mathbf{r}, t)$ at position $\mathbf{r
 + c m w(\mathbf{r}, t) = P(t)\delta(\mathbf{r} - \mathbf{r}_s)
 ```
 
-where $\frac{\partial^2}{\partial x^2}$, $\frac{\partial^2}{\partial y^2}$, $\frac{\partial^2}{\partial z^2}$ are the Laplace operators and $D = \frac{\lambda c}{3}$ is the so-called theoretical diffusion coefficient with $c$ being the speed of sound. The diffusion coefficient is a constant value that takes into account the room geometry and volume trough the mean free path defined for proportionate rooms as $\lambda = \frac{4 V}{S}$ with volume $V$ of the room and $S$ the total surface area. The term $P(t)$ indicates a sound source term at position $r_s$. The term $c m w(\mathbf{r}, t)$ accounts for the atmospheric attenuation within the room, where $m$ is the absorption coefficient of air (Billon et al., 2008).
+where $\frac{\partial^2}{\partial x^2}$, $\frac{\partial^2}{\partial y^2}$, $\frac{\partial^2}{\partial z^2}$ are the Laplace operators and $D = \frac{\lambda c}{3}$ is the so-called theoretical diffusion coefficient with $c$ being the speed of sound. The diffusion coefficient is a constant value that takes into account the room geometry and volume through the mean free path defined for proportionate rooms as $\lambda = \frac{4 V}{S}$ with volume $V$ of the room and $S$ the total surface area. The term $P(t)$ indicates a sound source term at position $r_s$. The term $c m w(\mathbf{r}, t)$ accounts for the atmospheric attenuation within the room, where $m$ is the absorption coefficient of air (Billon et al., 2008).
 
 The main partial differential equation is associated with mixed boundary conditions on a domain $\partial V$, as follows:
 

--- a/doc/Finite Difference Method Use.md
+++ b/doc/Finite Difference Method Use.md
@@ -58,7 +58,7 @@ The surface materials are defined within the inputs variable section of the pyth
 
 ### Frequency range
 The frequency range for this method is defined within the _PrepareInputsFVM.py_ python script. 
-The frequency resolution should be included as inputs variables *fc_low* and *fc_high*; these should be the center frequency of a band. The maximum number of frequencies is set in octave bands and can be choosen by the user. Normally, *fc_low* is set to 125 Hz and *fc_high* is set to 2000 Hz. The octave setting must be defined: set to 1 for one-octave bands or 3 for third-octave bands
+The frequency resolution should be included as inputs variables *fc_low* and *fc_high*; these should be the center frequency of a band. The maximum number of frequencies is set in octave bands and can be chosen by the user. Normally, *fc_low* is set to 125 Hz and *fc_high* is set to 2000 Hz. The octave setting must be defined: set to 1 for one-octave bands or 3 for third-octave bands
 
 ### Spatial discretization $\Delta x$
 The Finite Different method works with a spatial discretization. The space is defined by a mesh grid of points at a distance $\Delta v$ between each other. The distance $\Delta v$ is equal for each dimension $x,y,z$, therefore $\Delta v = \Delta x = \Delta y = \Delta z$, and it is defined in meters. 
@@ -120,7 +120,7 @@ The Clarity ($C_{80}$) parameter is the early to late arriving sound energy rati
 C_{80} = 10 \log_{10} \left( \frac{\int_0^{80\,\mathrm{ms}} p^2(t) \, dt}{\int_{80\,\mathrm{ms}}^\infty p^2 (t) \, dt} \right ) \,  [dB]
 ```
 
-The Definition ($D_{50}$) parameter is the ratio of the early received sound energy (0-50ms after direct sound arrival) to the total received energy. It referres only to the speech and it is defined as: 
+The Definition ($D_{50}$) parameter is the ratio of the early received sound energy (0-50ms after direct sound arrival) to the total received energy. It refers only to the speech and it is defined as: 
 
 ```{math}
 D_{50} = 10 \log \left( \frac{\int_0^{50\,\mathrm{ms}} p^2(t) \, dt}{\int_0^\infty p^2 (t) \, dt} \right ) \,  [\%]

--- a/doc/Finite Volume Method Use.md
+++ b/doc/Finite Volume Method Use.md
@@ -32,7 +32,7 @@ In order to create a volumetric mesh of the room with SketchUp Pro, the followin
 2. In the MeshKit extension banner in SketchUp software, set the active mesher to gmsh by clicking on the "edit configuration button" 
 ![editconfigurationbutton](images/editconfigurationbutton.png)
 3. Include the Gmsh Path of the gmsh.exe and select gmsh as the active mesher;
-4. Group the overal geometry (surfaces and edges) bounding the internal air volume by selecting everything, right-clicking and clicking "Make Group";
+4. Group the overall geometry (surfaces and edges) bounding the internal air volume by selecting everything, right-clicking and clicking "Make Group";
 5. Select the Group and click "Set selected as an smesh region and define properties" ![Set selected as an smesh region and define properties](images/setselectedasansmeshregion.png) in MeshKit;
 6. In the "Region Options: gmsh" menu, keep all the default option but change only the name of the region by writing, for example, "RoomVolume" and click "ok";
 7. Open the group by double clicking on the object;
@@ -133,7 +133,7 @@ The model allows for the insertion of only one acoustics receiver position per c
 
 #### Frequency range
 The frequency range for this method is defined within the _PrepareInputsFVM.py_ python script. 
-The frequency resolution should be included as inputs variables *fc_low* and *fc_high*; these should be the center frequency of a band. The maximum number of frequencies is set in octave bands and can be choosen by the user. Normally, *fc_low* is set to 125 Hz and *fc_high* is set to 2000 Hz. The octave setting must be defined: set to 1 for one-octave bands or 3 for third-octave bands.
+The frequency resolution should be included as inputs variables *fc_low* and *fc_high*; these should be the center frequency of a band. The maximum number of frequencies is set in octave bands and can be chosen by the user. Normally, *fc_low* is set to 125 Hz and *fc_high* is set to 2000 Hz. The octave setting must be defined: set to 1 for one-octave bands or 3 for third-octave bands.
 
 #### Time discretization dt
 The time discretization for this method is defined within the _FVM.py_ python script. 
@@ -203,7 +203,7 @@ The Clarity ($C_{80}$) parameter is the early to late arriving sound energy rati
 C_{80} = 10 \log_{10} \left( \frac{\int_0^{80\,\mathrm{ms}} p^2(t) \, dt}{\int_{80\,\mathrm{ms}}^\infty p^2 (t) \, dt} \right ) \,  [dB]
 ```
 
-The Definition ($D_{50}$) parameter is the ratio of the early received sound energy (0-50ms after direct sound arrival) to the total received energy. It referres only to the speech and it is defined as: 
+The Definition ($D_{50}$) parameter is the ratio of the early received sound energy (0-50ms after direct sound arrival) to the total received energy. It refers only to the speech and it is defined as: 
 
 ```{math}
 D_{50} = 10 \log_{10} \left( \frac{\int_0^{50\,\mathrm{ms}} p^2(t) \, dt}{\int_0^\infty p^2 (t) \, dt} \right ) \,  [\%]

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -86,7 +86,7 @@ Figure 1. SPL decay (left) and reverberation time T30 (right) for a 3 x 3 x 3 [m
 ## Design trade-offs
 The design of `acousticDE` is based on architectural choices shaped by the needs of room acoustics simulation research, which are transparency, reproducibility and modularity. The software is implemented in Python, since it is open-source and widely accessible compared to licensed alternatives, i.e. Matlab. In addition, it is an easier and more understandable language for researchers and for users from different fields compared to lower level languages such as C++ and Fortran.
 
-**Method-centric modularity:** Rather than implementing a single abstract solver interface, `acousticDE` is organised around self contained modules: FDM, FVM and Auralization. 
+**Method-centric modularity:** Rather than implementing a single abstract solver interface, `acousticDE` is organised around self cointained modules: FDM, FVM and Auralization. 
 
 Each module exposes a clear functional API like 'run_fvm_sim(...)' and maintains its own workflow. This structure mirrors typical room-acoustics workflows and prioritises clarity over complex abstraction layers. While the software is developed as a stand-alone project, its architecture allows for potential future integration or coupling with other tools (such as the image source method for the early part of the decay), providing that a common input generation framework is used.
 
@@ -106,7 +106,7 @@ This pipeline was intentionally chosen to make each stage of the modelling proce
 
 ## Software validation
 
-Results of the software have been validated against published studies, measurements results, and external methods such as the acoustics radiosity method [@Koutsouris2013CombinationMethod] and the sound particle tracing method [@ISimpa2012] and via informal auralization experiments. Integration testing of the main simulation engine (point 4 of the pipeline before mentioned) are in place to verify that the complete system functions seamlessly and that each of its submodules interacts correctly between each other. State verification against expected results are also implemented in the automatic tests. To complement the validation of the numerical results, the software is also profiled to ensure its robust performance under continuous changes.
+Results of the software have been validated against published studies, measurements results, and external methods such as the acoustics radiosity method [@Koutsouris2013CombinationMethod] and the sound particle tracing method [@ISimpa2012] and via informal auralization experiments. Integration testing of the main simulation engine (point 4 of the pipeline before mentioned) are in place to verify that the complete system functions seamlessy and that each of its submodules interacts correctly between each other. State verification against expected results are also implemented in the automatic tests. To complement the validation of the numerical results, the software is also profiled to ensure its robust performance under continuous changes.
 
 
 # Research impact assessment

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -86,7 +86,7 @@ Figure 1. SPL decay (left) and reverberation time T30 (right) for a 3 x 3 x 3 [m
 ## Design trade-offs
 The design of `acousticDE` is based on architectural choices shaped by the needs of room acoustics simulation research, which are transparency, reproducibility and modularity. The software is implemented in Python, since it is open-source and widely accessible compared to licensed alternatives, i.e. Matlab. In addition, it is an easier and more understandable language for researchers and for users from different fields compared to lower level languages such as C++ and Fortran.
 
-**Method-centric modularity:** Rather than implementing a single abstract solver interface, `acousticDE` is organised around self cointained modules: FDM, FVM and Auralization. 
+**Method-centric modularity:** Rather than implementing a single abstract solver interface, `acousticDE` is organised around self contained modules: FDM, FVM and Auralization. 
 
 Each module exposes a clear functional API like 'run_fvm_sim(...)' and maintains its own workflow. This structure mirrors typical room-acoustics workflows and prioritises clarity over complex abstraction layers. While the software is developed as a stand-alone project, its architecture allows for potential future integration or coupling with other tools (such as the image source method for the early part of the decay), providing that a common input generation framework is used.
 
@@ -106,7 +106,7 @@ This pipeline was intentionally chosen to make each stage of the modelling proce
 
 ## Software validation
 
-Results of the software have been validated against published studies, measurements results, and external methods such as the acoustics radiosity method [@Koutsouris2013CombinationMethod] and the sound particle tracing method [@ISimpa2012] and via informal auralization experiments. Integration testing of the main simulation engine (point 4 of the pipeline before mentioned) are in place to verify that the complete system functions seamlessy and that each of its submodules interacts correctly between each other. State verification against expected results are also implemented in the automatic tests. To complement the validation of the numerical results, the software is also profiled to ensure its robust performance under continuous changes.
+Results of the software have been validated against published studies, measurements results, and external methods such as the acoustics radiosity method [@Koutsouris2013CombinationMethod] and the sound particle tracing method [@ISimpa2012] and via informal auralization experiments. Integration testing of the main simulation engine (point 4 of the pipeline before mentioned) are in place to verify that the complete system functions seamlessly and that each of its submodules interacts correctly between each other. State verification against expected results are also implemented in the automatic tests. To complement the validation of the numerical results, the software is also profiled to ensure its robust performance under continuous changes.
 
 
 # Research impact assessment


### PR DESCRIPTION
Fixes 11 spelling mistakes in the docs, found with `codespell`.

Prose only. No code identifiers, dependency names or proper nouns changed, and anything that was a valid word rather than a misspelling was left alone.

Two of these are in `paper/paper.md`, happy to drop those if you would rather not touch the paper during review.